### PR TITLE
Fix getSpelling missing case issue #33

### DIFF
--- a/src-library/MidiMessage.cpp
+++ b/src-library/MidiMessage.cpp
@@ -1086,7 +1086,7 @@ void MidiMessage::getSpelling(int& base7, int& accidental) {
       case 4:
          switch (spelling) {
                     case 1: base7pc = 3; accidental = -1; break;  // Fb
-                    case 2: base7pc = 2; accidental =  0; break;  // E
+            case 0: case 2: base7pc = 2; accidental =  0; break;  // E
                     case 3: base7pc = 1; accidental = +2; break;  // D##
          }
          break;


### PR DESCRIPTION
It appears this was simply missing; a note example is 76 @ velocity 80 yields an invalid accidental (just an E 2 above middle C with default volume from MuseScore).
