### PR TITLE
"add/remove" events options added to midi event list class

### DIFF
--- a/include/MidiEventList.h
+++ b/include/MidiEventList.h
@@ -45,6 +45,9 @@ class MidiEventList {
       int         push_back        (MidiEvent& event);
       int         append           (MidiEvent& event);
 
+      int         remove           (int index);
+      int         add              (int index, MidiEvent& event);
+
       // careful when using these, intended for internal use in MidiFile class:
       void        detach              (void);
       int         push_back_no_copy   (MidiEvent* event);
@@ -58,6 +61,3 @@ class MidiEventList {
 
 
 #endif /* _MIDIEVENTLIST_H_INCLUDED */
-
-
-

--- a/src-library/MidiEventList.cpp
+++ b/src-library/MidiEventList.cpp
@@ -197,6 +197,38 @@ int MidiEventList::push_back(MidiEvent& event) {
    return append(event);
 }
 
+//////////////////////////////
+//
+// MidiEventList::remove -- deletes a MidiEvent at the specified index. If
+//      the index is invalid then the request is ignored and -1 is returned.
+//      If the index is valid then the new size of the list is returned.
+//
+int MidiEventList::remove(int index) {
+   if ( ( index >=0 ) && ( index < (int)list.size() ) ) {
+     list.erase(list.begin() + index);
+     return (int)list.size()-1;
+   } else {
+     return -1;
+   }
+}
+
+
+//////////////////////////////
+//
+// MidiEventList::add -- inserts a MidiEvent at the specified index. If
+//      the index is invalid then the request is ignored and -1 is returned.
+//      If the index is valid then the new size of the list is returned.
+//
+int MidiEventList::add(int index, MidiEvent& event) {
+  if ( ( index >=0 ) && ( index < (int)list.size() ) ) {
+   MidiEvent* ptr = new MidiEvent(event);
+   list.insert(list.begin()+index, ptr);
+   return (int)list.size()-1;
+ } else {
+   return -1;
+ }
+}
+
 
 //////////////////////////////
 //
@@ -404,5 +436,3 @@ MidiEventList& MidiEventList::operator=(MidiEventList other) {
    list.swap(other.list);
    return *this;
 }
-
-


### PR DESCRIPTION
The new options need the index into the events list ( and the new event in the "add" case ). If the operation is successful then the new size of the list is returned otherwise -1 is returned.