### PR TITLE
The std::vector argument to addMetaEvent should be const.

### DIFF
--- a/include/MidiFile.h
+++ b/include/MidiFile.h
@@ -182,7 +182,7 @@ class MidiFile {
 		// Meta-event adding convenience functions:
 		MidiEvent*         addMetaEvent           (int aTrack, int aTick,
 		                                           int aType,
-		                                           std::vector<uchar>& metaData);
+		                                           const std::vector<uchar>& metaData);
 		MidiEvent*         addMetaEvent           (int aTrack, int aTick,
 		                                           int aType,
 		                                           const std::string& metaData);

--- a/src-library/MidiFile.cpp
+++ b/src-library/MidiFile.cpp
@@ -1536,7 +1536,7 @@ MidiEvent* MidiFile::addEvent(int aTrack, MidiEvent& mfevent) {
 //
 
 MidiEvent* MidiFile::addMetaEvent(int aTrack, int aTick, int aType,
-		std::vector<uchar>& metaData) {
+		const std::vector<uchar>& metaData) {
 	m_timemapvalid = 0;
 	int i;
 	int length = (int)metaData.size();


### PR DESCRIPTION
The version of the `addMetaEvent` function that takes the `metaData` as a `std::vector` type should accept that `std::vector` argument as a `const` type.  Otherwise, callers of this function that pass data from constant member functions and/or retrieve their data from constant getter functions have to either do a `const_cast` or declare their own types mutable and/or add temporary variables of a non-const type when they shouldn't need to.
