### PR TITLE
Explicitly call std::vector assignment operator

### DIFF
--- a/include/MidiFile.h
+++ b/include/MidiFile.h
@@ -165,6 +165,10 @@ class MidiFile {
 		MidiEvent*        addPitchBend            (int aTrack, int aTick,
 		                                           int aChannel, double amount);
 
+		// RPN settings:
+		void              setPitchBendRange       (int aTrack, int aTick,
+		                                           int aChannel, double range);
+
 		// Controller message adding convenience functions:
 		MidiEvent*        addSustain              (int aTrack, int aTick,
 		                                           int aChannel, int value);

--- a/src/Binasc.cpp
+++ b/src/Binasc.cpp
@@ -881,6 +881,9 @@ int Binasc::readMidiEvent(std::ostream& out, std::istream& infile,
 						   for (int i=0; i<length; i++) {
 						      infile.read((char*)&ch, 1);
 						      trackbytes++;
+								if (ch == '"') {
+									output << '\\';
+								}
 						      output << (char)ch;
 						   }
 						   output << "\"";

--- a/src/MidiFile.cpp
+++ b/src/MidiFile.cpp
@@ -1939,6 +1939,43 @@ MidiEvent* MidiFile::addPitchBend(int aTrack, int aTick, int aChannel, double am
 }
 
 
+
+///////////////////////////////////////////////////////////////////////////
+//
+// RPN convenience functions:
+//
+
+//////////////////////////////
+//
+// MidiFile::setPitchBendRange -- Set the range for the min/max pitch bend
+//   alteration of a note.  Default is 2.0 (meaning +/- 2 semitones from given pitch).
+//   Fractional values are cents, so 2.5 means a range of two semitones plus 50 cents,
+//   which is two semitones plus a quarter tone.
+//
+
+void MidiFile::setPitchBendRange(int aTrack, int aTick, int aChannel, double range) {
+	if (range < 0.0) {
+		range = -range;
+	}
+	if (range > 24.0) {
+		std::cerr << "Warning: pitch bend range is too large: " << range << std::endl;
+		std::cerr << "Setting to 24." << std::endl;
+		range = 24.0;
+	}
+	int irange = int(range);
+	int cents = int((range - irange) * 100.0 + 0.5);
+
+	// Select pitch bend RPN:
+	addController(aTrack, aTick, aChannel, 101, 0);  // RPN selector (byte 1)
+	addController(aTrack, aTick, aChannel, 100, 0);  // RPN selector (byte 2)
+
+	// Set the semitone range (will be +/-range above/below a note):
+	addController(aTrack, aTick, aChannel,  6,  irange);  // coarse: number of semitones
+	addController(aTrack, aTick, aChannel, 38,  cents);   // fine: cents (1/100ths of semitone)
+}
+
+
+
 ///////////////////////////////////////////////////////////////////////////
 //
 // Controller message adding convenience functions:

--- a/src/MidiMessage.cpp
+++ b/src/MidiMessage.cpp
@@ -89,7 +89,7 @@ MidiMessage& MidiMessage::operator=(const MidiMessage& message) {
 	if (this == &message) {
 		return *this;
 	}
-	(*this) = message;
+	std::vector<uchar>::operator=(static_cast<const std::vector<uchar> &>(message));
 	return *this;
 }
 


### PR DESCRIPTION
Found and fixed issue with the assignment operator operator for this class, where in a gcc 7.4 compiled program the MidiMessage operator would be called recursively.
Simple fix is to explicitly call the parent class operator.