### PR TITLE
Fix windows warning

### DIFF
--- a/src/Binasc.cpp
+++ b/src/Binasc.cpp
@@ -375,7 +375,7 @@ int Binasc::outputStyleAscii(std::ostream& out, std::istream& input) {
 	int type      = 0;             // 0=space, 1=printable
 	uchar ch;                      // current input byte
 
-	ch = input.get();
+	ch = static_cast<uchar>(input.get());
 	while (!input.eof()) {
 		int lastType = type;
 		type = (isprint(ch) && !isspace(ch)) ? 1 : 0;
@@ -401,7 +401,7 @@ int Binasc::outputStyleAscii(std::ostream& out, std::istream& input) {
 		if (type == 1) {
 			outputWord[index++] = ch;
 		}
-		ch = input.get();
+		ch = static_cast<uchar>(input.get());
 	}
 
 	if (index != 0) {
@@ -423,7 +423,7 @@ int Binasc::outputStyleBinary(std::ostream& out, std::istream& input) {
 	int currentByte = 0;    // current byte output in line
 	uchar ch;               // current input byte
 
-	ch = input.get();
+	ch = static_cast<uchar>(input.get());
 	if (input.eof()) {
 		std::cerr << "End of the file right away!" << std::endl;
 		return 0;
@@ -439,7 +439,7 @@ int Binasc::outputStyleBinary(std::ostream& out, std::istream& input) {
 			out << '\n';
 			currentByte = 0;
 		}
-		ch = input.get();
+		ch = static_cast<uchar>(input.get());
 	}
 
 	if (currentByte != 0) {
@@ -463,7 +463,7 @@ int Binasc::outputStyleBoth(std::ostream& out, std::istream& input) {
 	int index = 0;                 // current character in asciiLine
 	uchar ch;                      // current input byte
 
-	ch = input.get();
+	ch = static_cast<uchar>(input.get());
 	while (!input.eof()) {
 		if (index == 0) {
 			asciiLine[index++] = ';';
@@ -490,7 +490,7 @@ int Binasc::outputStyleBoth(std::ostream& out, std::istream& input) {
 			currentByte = 0;
 			index = 0;
 		}
-		ch = input.get();
+		ch = static_cast<uchar>(input.get());
 	}
 
 	if (currentByte != 0) {
@@ -1429,8 +1429,6 @@ int Binasc::processDecimalWord(std::ostream& out, const std::string& word,
 			std::cerr << "invalid byte count specification for decimal number" << std::endl;
 			return 0;
 	}
-
-	return 1;
 }
 
 

--- a/src/MidiEventList.cpp
+++ b/src/MidiEventList.cpp
@@ -292,8 +292,7 @@ int MidiEventList::linkNotePairs(void) {
 	// dimension 3: List of active note-ons or note-offs.
 	std::vector<std::vector<std::vector<MidiEvent*>>> noteons;
 	noteons.resize(16);
-	int i;
-	for (i=0; i<(int)noteons.size(); i++) {
+	for (int i=0; i<(int)noteons.size(); i++) {
 		noteons[i].resize(128);
 	}
 
@@ -368,7 +367,7 @@ int MidiEventList::linkNotePairs(void) {
 	int counter = 0;
 	MidiEvent* mev;
 	MidiEvent* noteon;
-	for (i=0; i<getSize(); i++) {
+	for (int i=0; i<getSize(); i++) {
 		mev = &getEvent(i);
 		mev->unlinkEvent();
 		if (mev->isNoteOn()) {

--- a/src/MidiFile.cpp
+++ b/src/MidiFile.cpp
@@ -502,15 +502,15 @@ bool MidiFile::write(std::ostream& out) {
 
 	// 3. MIDI file format, type 0, 1, or 2
 	ushort shortdata;
-	shortdata = (getNumTracks() == 1) ? 0 : 1;
+	shortdata = static_cast<ushort>(getNumTracks() == 1 ? 0 : 1);
 	writeBigEndianUShort(out,shortdata);
 
 	// 4. write out the number of tracks.
-	shortdata = getNumTracks();
+	shortdata = static_cast<ushort>(getNumTracks());
 	writeBigEndianUShort(out, shortdata);
 
 	// 5. write out the number of ticks per quarternote. (avoiding SMTPE for now)
-	shortdata = getTicksPerQuarterNote();
+	shortdata = static_cast<ushort>(getTicksPerQuarterNote());
 	writeBigEndianUShort(out, shortdata);
 
 	// now write each track.
@@ -931,16 +931,16 @@ void MidiFile::splitTracks(void) {
 			maxTrack = (*m_events[0])[i].track;
 		}
 	}
-	int m_trackCount = maxTrack + 1;
+	int trackCount = maxTrack + 1;
 
-	if (m_trackCount <= 1) {
+	if (trackCount <= 1) {
 		return;
 	}
 
 	MidiEventList* olddata = m_events[0];
 	m_events[0] = NULL;
-	m_events.resize(m_trackCount);
-	for (i=0; i<m_trackCount; i++) {
+	m_events.resize(trackCount);
+	for (i=0; i<trackCount; i++) {
 		m_events[i] = new MidiEventList;
 	}
 
@@ -995,16 +995,16 @@ void MidiFile::splitTracksByChannel(void) {
 			maxTrack = eventlist[i][0] & 0x0f;
 		}
 	}
-	int m_trackCount = maxTrack + 2; // + 1 for expression track
+	int trackCount = maxTrack + 2; // + 1 for expression track
 
-	if (m_trackCount <= 1) {
+	if (trackCount <= 1) {
 		// only one channel, so don't do anything (leave as Type-0 file).
 		return;
 	}
 
 	m_events[0] = NULL;
-	m_events.resize(m_trackCount);
-	for (i=0; i<m_trackCount; i++) {
+	m_events.resize(trackCount);
+	for (i=0; i<trackCount; i++) {
 		m_events[i] = new MidiEventList;
 	}
 

--- a/src/MidiMessage.cpp
+++ b/src/MidiMessage.cpp
@@ -934,7 +934,7 @@ void MidiMessage::setP0(int value) {
 	if (getSize() < 1) {
 		resize(1);
 	}
-	(*this)[0] = value;
+	(*this)[0] = static_cast<uchar>(value);
 }
 
 
@@ -952,7 +952,7 @@ void MidiMessage::setP1(int value) {
 	if (getSize() < 2) {
 		resize(2);
 	}
-	(*this)[1] = value;
+	(*this)[1] = static_cast<uchar>(value);
 }
 
 
@@ -971,7 +971,7 @@ void MidiMessage::setP2(int value) {
 	if (getSize() < 3) {
 		resize(3);
 	}
-	(*this)[2] = value;
+	(*this)[2] = static_cast<uchar>(value);
 }
 
 
@@ -990,7 +990,7 @@ void MidiMessage::setP3(int value) {
 	if (getSize() < 4) {
 		resize(4);
 	}
-	(*this)[3] = value;
+	(*this)[3] = static_cast<uchar>(value);
 }
 
 
@@ -1341,7 +1341,7 @@ void MidiMessage::setSpelling(int base7, int accidental) {
 
 	}
 
-	uchar vel = getVelocity();
+	uchar vel = static_cast<uchar>(getVelocity());
 	// suppress any previous content in the first two bits:
 	vel = vel & 0xFC;
 	// insert the spelling code:

--- a/src/Options.cpp
+++ b/src/Options.cpp
@@ -823,7 +823,6 @@ void Options::appendOptions(const std::vector<std::string>& argv) {
 //
 
 void Options::appendOptions(const std::string& strang) {
-   int i;
    int doublequote = 0;
    int singlequote = 0;
 
@@ -835,10 +834,10 @@ void Options::appendOptions(const std::string& strang) {
    tempargv.reserve(100);
    tempvalue.reserve(1000);
 
-   char ch;
+   char ch = '\0';
 
    int length = (int)strang.size();
-   for (i=0; i<length; i++) {
+   for (int i=0; i<length; i++) {
 
       if (!singlequote && (strang[i] == '"')) {
          if ((i>0) && (strang[i-1] != '\\')) {
@@ -895,7 +894,7 @@ void Options::appendOptions(const std::string& strang) {
    // assemble the argv structure
 
    tempargv.reserve(tokens.size());
-   for (i=0; i<(int)tempargv.size(); i++) {
+   for (int i=0; i<(int)tempargv.size(); i++) {
       tempargv[i] = tokens[i];
    }
 


### PR DESCRIPTION
Fix some warning on lib sources while windows compilation with the `/W4` flag (with cl.exe)

- Type static_cast (C4244 warning code)
- Unreachable code `return 1;`, in all switch case (including default) there is a return
- Rename `m_trackCount` into `trackCount` (conflit name between class property and local variable)
- Initialize some variable with a default value

Thanks for your work!!