### PR TITLE
add missing cmath include

### DIFF
--- a/src/MidiMessage.cpp
+++ b/src/MidiMessage.cpp
@@ -13,6 +13,7 @@
 
 #include "MidiMessage.h"
 
+#include <cmath>
 #include <iostream>
 #include <iterator>
 #include <stdlib.h>


### PR DESCRIPTION
I was unable to build with latest changes using cmake

FetchContent_Declare(
  midifile
  GIT_REPOSITORY https://github.com/justinharding/midifile.git
}

 - pow and log2 were undefined in MidiMessage.cpp
 
This pull request just adds a header