### PR TITLE
Do not push size of the data into the SysEx

### DIFF
--- a/src/MidiMessage.cpp
+++ b/src/MidiMessage.cpp
@@ -1972,11 +1972,6 @@ void MidiMessage::makeSysExMessage(const std::vector<uchar>& data) {
 
 	this->push_back((uchar)0xf0);
 
-	int msize = endindex - startindex + 2;
-	std::vector<uchar> vlv = intToVlv(msize);
-	for (int i=0; i<(int)vlv.size(); i++) {
-		this->push_back(vlv[i]);
-	}
 	for (int i=startindex; i<=endindex; i++) {
 		this->push_back(data.at(i));
 	}


### PR DESCRIPTION
I've done some testing with [mts-type2.cpp](https://github.com/craigsapp/midifile/blob/master/tools/mts-type2.cpp) and adding size to the SysEx seems to break the functionality. The message is ignored and no tune changes are made.

Here is an archive with two WAV files (converted from MIDI to WAV via Timidity) and two original MIDI files. **quarter_with_size** has size of the data array added to the message, while **quarter_without_size** - does not.
[quarters.zip](https://github.com/craigsapp/midifile/files/8868157/quarters.zip)

Additionally, if I were to compare results from https://github.com/craigsapp/midifile/issues/99 with the ones that I get, they seem to match with the ones, made without adding size.
Size of file from archive in [this](https://github.com/craigsapp/midifile/issues/99#issuecomment-1136584853) matches with the size of MIDI generated without size (368 bytes). As does MIDI generated from Ratioscore lack this one byte, representing size of the SysEx message.