### PR TITLE
Add helper for setting key

### DIFF
--- a/include/MidiFile.h
+++ b/include/MidiFile.h
@@ -218,7 +218,7 @@ class MidiFile {
 		                                           double aTempo);
         MidiEvent*         addKeySignature        (int aTrack, int aTick,
                                                    int key, bool mode = 0);
-		MidiEvent*         addTimeSignature       (int aTrack, int aTick,
+        MidiEvent*         addTimeSignature       (int aTrack, int aTick,
 		                                           int top, int bottom,
 		                                           int clocksPerClick = 24,
 		                                           int num32dsPerQuarter = 8);

--- a/include/MidiFile.h
+++ b/include/MidiFile.h
@@ -216,9 +216,9 @@ class MidiFile {
 		                                           const std::string& text);
 		MidiEvent*         addTempo               (int aTrack, int aTick,
 		                                           double aTempo);
-        MidiEvent*         addKeySignature        (int aTrack, int aTick,
-                                                   int key, bool mode = 0);
-        MidiEvent*         addTimeSignature       (int aTrack, int aTick,
+		MidiEvent*         addKeySignature        (int aTrack, int aTick,
+		                                           int key, bool mode = 0);
+		MidiEvent*         addTimeSignature       (int aTrack, int aTick,
 		                                           int top, int bottom,
 		                                           int clocksPerClick = 24,
 		                                           int num32dsPerQuarter = 8);

--- a/include/MidiFile.h
+++ b/include/MidiFile.h
@@ -216,6 +216,8 @@ class MidiFile {
 		                                           const std::string& text);
 		MidiEvent*         addTempo               (int aTrack, int aTick,
 		                                           double aTempo);
+        MidiEvent*         addKeySignature        (int aTrack, int aTick,
+                                                   int key, bool mode = 0);
 		MidiEvent*         addTimeSignature       (int aTrack, int aTick,
 		                                           int top, int bottom,
 		                                           int clocksPerClick = 24,

--- a/include/MidiFile.h
+++ b/include/MidiFile.h
@@ -217,7 +217,7 @@ class MidiFile {
 		MidiEvent*         addTempo               (int aTrack, int aTick,
 		                                           double aTempo);
 		MidiEvent*         addKeySignature        (int aTrack, int aTick,
-		                                           int key, bool mode = 0);
+		                                           int fifths, bool mode = 0);
 		MidiEvent*         addTimeSignature       (int aTrack, int aTick,
 		                                           int top, int bottom,
 		                                           int clocksPerClick = 24,

--- a/include/MidiMessage.h
+++ b/include/MidiMessage.h
@@ -140,7 +140,7 @@ class MidiMessage : public std::vector<uchar> {
 		void           makeLyric            (const std::string& text);
 		void           makeMarker           (const std::string& text);
 		void           makeCue              (const std::string& text);
-        void           makeKeySignature     (int fifths, bool mode = 0);
+		void           makeKeySignature     (int fifths, bool mode = 0);
 		void           makeTimeSignature    (int top, int bottom,
 		                                     int clocksPerClick = 24,
 		                                     int num32dsPerQuarter = 8);

--- a/include/MidiMessage.h
+++ b/include/MidiMessage.h
@@ -140,6 +140,7 @@ class MidiMessage : public std::vector<uchar> {
 		void           makeLyric            (const std::string& text);
 		void           makeMarker           (const std::string& text);
 		void           makeCue              (const std::string& text);
+        void           makeKeySignature     (int fifths, bool mode = 0);
 		void           makeTimeSignature    (int top, int bottom,
 		                                     int clocksPerClick = 24,
 		                                     int num32dsPerQuarter = 8);

--- a/src/MidiFile.cpp
+++ b/src/MidiFile.cpp
@@ -1846,6 +1846,30 @@ MidiEvent* MidiFile::addTempo(int aTrack, int aTick, double aTempo) {
 
 //////////////////////////////
 //
+// MidiFile::addKeySignature -- Add a key signature meta message
+//      (meta #0x59).
+//
+// Default values:
+//      fifths ==  0 (C)
+//      mode   ==  0 (major)
+//
+// Key signature of b minor would be:
+//      fifths = 2
+//      mode   = 1
+//
+
+MidiEvent* MidiFile::addKeySignature (int aTrack, int aTick, int fifths, bool mode) {
+    MidiEvent* me = new MidiEvent;
+    me->makeKeySignature(fifths, mode);
+    me->tick = aTick;
+    m_events[aTrack]->push_back_no_copy(me);
+    return me;
+}
+
+
+
+//////////////////////////////
+//
 // MidiFile::addTimeSignature -- Add a time signature meta message
 //      (meta #0x58).  The "bottom" parameter must be a power of two;
 //      otherwise, it will be set to the next highest power of two.

--- a/src/MidiMessage.cpp
+++ b/src/MidiMessage.cpp
@@ -1596,6 +1596,31 @@ void MidiMessage::setTempoMicroseconds(int microseconds) {
 
 //////////////////////////////
 //
+// MidiMessage::makeKeySignature -- create a key signature meta message
+//      (meta #0x59).
+//
+// Default values:
+//      fifths ==  0 (C)
+//      mode   ==  0 (major)
+//
+// Key signature of b minor would be:
+//      fifths = 2
+//      mode   = 1
+//
+
+void MidiMessage::makeKeySignature(int fifths, bool mode) {
+    resize(5);
+    (*this)[0] = 0xff;
+    (*this)[1] = 0x59;
+    (*this)[2] = 0x02;
+    (*this)[3] = 0xff & fifths;
+    (*this)[4] = 0xff & (int)mode;
+}
+
+
+
+//////////////////////////////
+//
 // MidiMessage::makeTimeSignature -- create a time signature meta message
 //      (meta #0x58).  The "bottom" parameter should be a power of two;
 //      otherwise, it will be forced to be the next highest power of two,


### PR DESCRIPTION
This PR adds convenient functions to set key signatures.

```cpp
void makeKeySignature (int fifths, bool mode = 0);
```

Similar to the `addTimeSignature` this PR adds an easy way to add a key signature meta event to a MIDI file: 

```cpp
MidiEvent* addKeySignature (int aTrack, int aTick, int key, bool mode = 0);
```
The `fifths` parameter specifies the position within the circle of fifths, the `mode` parameter specifies if this is a minor key.

In the following case we add a D major key to track 2 and a G minor to track 3: 
```cpp
addKeySignature(1, 0, 2, 0}
addKeySignature(2, 0, -2, 1}
```

<img width="996" alt="image" src="https://user-images.githubusercontent.com/7693447/176183834-b879f8d9-2381-466e-9c1b-1169511ddeee.png">

When opening this in MuseScore, it will read this information and render accordingly:
<img width="493" alt="image" src="https://user-images.githubusercontent.com/7693447/176183978-6d49c233-536f-4539-bf62-69c0bc6fd453.png">

NB: MIDI only differentiates between _major_ and _minor_, that's why a boolean is used as forth parameter. It is major by default. 
