### PR TITLE
Allow static and shared builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ set(HDRS
     include/Options.h
 )
 
-add_library(midifile STATIC ${SRCS} ${HDRS})
+add_library(midifile ${SRCS} ${HDRS})
 
 ##############################
 ##


### PR DESCRIPTION
Implements @brechtsanders's suggestion to allow the builder to specify the type of the installed craigsapp/midifile library with CMake. 

References:
   * #78
   * [BUILD_SHARED_LIBS CMake documentation](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html#variable:BUILD_SHARED_LIBS)

## Sample execution specifying a static library
```
dhorlick@brogmoid:~/diy/forks/midifile/build$ cmake ..
-- The C compiler identification is GNU 9.4.0
-- The CXX compiler identification is GNU 9.4.0
⋮
-- Configuring done
-- Generating done
-- Build files have been written to: /home/dhorlick/diy/forks/midifile/build
```
```
dhorlick@brogmoid:~/diy/forks/midifile/build$ make
Scanning dependencies of target midifile
[  0%] Building CXX object CMakeFiles/midifile.dir/src/Options.cpp.o
[  1%] Building CXX object CMakeFiles/midifile.dir/src/Binasc.cpp.o
[  2%] Building CXX object CMakeFiles/midifile.dir/src/MidiEvent.cpp.o
[  3%] Building CXX object CMakeFiles/midifile.dir/src/MidiEventList.cpp.o
[  4%] Building CXX object CMakeFiles/midifile.dir/src/MidiFile.cpp.o
[  5%] Building CXX object CMakeFiles/midifile.dir/src/MidiMessage.cpp.o
[  6%] Linking CXX static library libmidifile.a
⋮
[ 98%] Built target midi2skini
[100%] Built target mididiss
```
```
dhorlick@brogmoid:~/diy/forks/midifile/build$ sudo make install
[  6%] Built target midifile
[  7%] Built target midimean
[  9%] Built target midirange
⋮
[ 98%] Built target midi2skini
[100%] Built target mididiss
Install the project...
-- Install configuration: ""
-- Installing: /usr/local/lib/libmidifile.a
-- Up-to-date: /usr/local/include/midifile/Binasc.h
-- Up-to-date: /usr/local/include/midifile/MidiEvent.h
-- Up-to-date: /usr/local/include/midifile/MidiEventList.h
-- Up-to-date: /usr/local/include/midifile/MidiFile.h
-- Up-to-date: /usr/local/include/midifile/MidiMessage.h
-- Up-to-date: /usr/local/include/midifile/Options.h
```
```
dhorlick@brogmoid:~/diy/forks/midifile/build$ ls /usr/local/lib/
libmidifile.a  luarocks  python2.7  python3.8
```

## Sample execution specifying a shared library
```
dhorlick@brogmoid:~/diy/forks/midifile/build$ cmake -DBUILD_SHARED_LIBS=ON ..
-- Configuring done
-- Generating done
-- Build files have been written to: /home/dhorlick/diy/forks/midifile/build
```
```
dhorlick@brogmoid:~/diy/forks/midifile/build$ make
[  0%] Building CXX object CMakeFiles/midifile.dir/src/Options.cpp.o
[  1%] Building CXX object CMakeFiles/midifile.dir/src/Binasc.cpp.o
[  2%] Building CXX object CMakeFiles/midifile.dir/src/MidiEvent.cpp.o
[  3%] Building CXX object CMakeFiles/midifile.dir/src/MidiEventList.cpp.o
[  4%] Building CXX object CMakeFiles/midifile.dir/src/MidiFile.cpp.o
[  5%] Building CXX object CMakeFiles/midifile.dir/src/MidiMessage.cpp.o
[  6%] Linking CXX shared library libmidifile.so
⋮
Scanning dependencies of target mididiss
[ 99%] Building CXX object CMakeFiles/mididiss.dir/tools/mididiss.cpp.o
[100%] Linking CXX executable mididiss
[100%] Built target mididiss
```
```
dhorlick@brogmoid:~/diy/forks/midifile/build$ sudo make install
[  6%] Built target midifile
[  7%] Built target midimean
[  9%] Built target midirange
⋮
[ 98%] Built target midi2skini
[100%] Built target mididiss
Install the project...
-- Install configuration: ""
-- Up-to-date: /usr/local/lib/libmidifile.so
-- Up-to-date: /usr/local/include/midifile/Binasc.h
-- Up-to-date: /usr/local/include/midifile/MidiEvent.h
-- Up-to-date: /usr/local/include/midifile/MidiEventList.h
-- Up-to-date: /usr/local/include/midifile/MidiFile.h
-- Up-to-date: /usr/local/include/midifile/MidiMessage.h
-- Up-to-date: /usr/local/include/midifile/Options.h
```
```
dhorlick@brogmoid:~/diy/forks/midifile/build$ ls /usr/local/lib/
libmidifile.so  luarocks  python2.7  python3.8
```