### PR TITLE
Fix const for MidiMessage::getMetaContent()

### DIFF
--- a/include/MidiMessage.h
+++ b/include/MidiMessage.h
@@ -173,7 +173,7 @@ class MidiMessage : public std::vector<uchar> {
 		bool           isKeySignature       (void) const;
 		bool           isEndOfTrack         (void) const;
 
-		std::string    getMetaContent       (void);
+		std::string    getMetaContent       (void) const;
 		void           setMetaContent       (const std::string& content);
 		void           setTempo             (double tempo);
 		void           setTempoMicroseconds (int microseconds);

--- a/src/MidiMessage.cpp
+++ b/src/MidiMessage.cpp
@@ -1495,7 +1495,7 @@ void MidiMessage::getSpelling(int& base7, int& accidental) {
 //   message after the length (which is a variable-length-value).
 //
 
-std::string MidiMessage::getMetaContent(void) {
+std::string MidiMessage::getMetaContent(void) const {
 	std::string output;
 	if (!isMetaMessage()) {
 		return output;


### PR DESCRIPTION
The method MidiMessage::getMetaContent() can (and should) be const.