### PR TITLE
Add alias target, and target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ check_include_files(unistd.h HAVE_UNISTD_H)
 check_include_files(humdrum.h HAVE_HUMDRUM_H)
 check_include_files(sys/io.h HAVE_SYS_IO_H)
 
-option(BUILD_MIDILIBRARY_ONLY "Build only the midifile library" OFF)
+option(BUILD_MIDILIBRARY_ONLY "Build only the midifile library" ON)
 
 ##############################
 ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ set(HDRS
 )
 
 add_library(midifile STATIC ${SRCS} ${HDRS})
+add_library(smf::midifile ALIAS midifile)
+target_include_directories(midifile PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
 ##############################
 ##


### PR DESCRIPTION
Currently when consuming via FetchContent, midifile's include dir is *not* added to the consumer's includes - this fixes this, and also exposes an alias target for midifile under the smf namespace, for clarity in where the library is coming from!